### PR TITLE
Fix Railway deployment by including dev dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN npm config set fund false && \
 # Copy package files
 COPY package.json package-lock.json* ./
 
-# Install dependencies with optimizations
-RUN npm ci --omit=dev --omit=optional --no-audit --no-fund --maxsockets 1
+# Install all dependencies including dev dependencies for build
+RUN npm ci --no-audit --no-fund --maxsockets 1
 
 # Copy source code
 COPY . .


### PR DESCRIPTION
## Purpose
The user was experiencing a deployment failure on Railway due to a missing `quasar` command during the build process. The error occurred because dev dependencies (including the Quasar CLI) were being omitted during npm install, but the postinstall script required `quasar prepare` to run successfully.

## Code changes
- Modified Dockerfile to install all dependencies (including dev dependencies) by removing `--omit=dev --omit=optional` flags from the `npm ci` command
- Updated comment to clarify that dev dependencies are needed for the build process
- Kept optimization flags `--no-audit --no-fund --maxsockets 1` for faster installation

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 15`

🔗 [Edit in Builder.io](https://builder.io/app/projects/afd61fb575e943daaa606140b29f7195/echo-works)

👀 [Preview Link](https://afd61fb575e943daaa606140b29f7195-echo-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>afd61fb575e943daaa606140b29f7195</projectId>-->
<!--<branchName>echo-works</branchName>-->